### PR TITLE
WIP: macOS Support

### DIFF
--- a/src/egs/epic_platform.rs
+++ b/src/egs/epic_platform.rs
@@ -28,7 +28,7 @@ impl Platform<ManifestItem, EpicGamesManifestsError> for EpicPlatform {
         get_egs_manifests(&self.settings)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         self.settings.create_symlinks
     }

--- a/src/egs/get_manifests.rs
+++ b/src/egs/get_manifests.rs
@@ -74,7 +74,7 @@ fn get_manifest_dir_path(
 }
 
 pub fn get_default_location() -> Option<PathBuf> {
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     {
         //No path defined for epic gamestore, and we cannot guess on linux
         None

--- a/src/egs/manifest_item.rs
+++ b/src/egs/manifest_item.rs
@@ -148,7 +148,7 @@ mod tests {
 
         #[cfg(target_os = "windows")]
         assert_eq!(shortcut.exe, "\"C:\\Games\\MarvelGOTG\\retail/gotg.exe\"");
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         assert_eq!(shortcut.exe, "\"C:\\Games\\MarvelGOTG/retail/gotg.exe\"");
 
         assert_eq!(shortcut.launch_options, "");

--- a/src/egs/settings.rs
+++ b/src/egs/settings.rs
@@ -5,6 +5,6 @@ pub struct EpicGamesLauncherSettings {
     pub enabled: bool,
     pub location: Option<String>,
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     pub create_symlinks: bool,
 }

--- a/src/gog/gog_platform.rs
+++ b/src/gog/gog_platform.rs
@@ -21,7 +21,7 @@ impl Platform<GogShortcut, GogErrors> for GogPlatform {
         "Gog"
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         self.settings.create_symlinks
     }
@@ -41,7 +41,7 @@ impl Platform<GogShortcut, GogErrors> for GogPlatform {
             return Err(GogErrors::ConfigFileNotFound { path: config_path });
         }
         let install_locations = get_install_locations(config_path)?;
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         let install_locations = if let Some(wine_c_drive) = &self.settings.wine_c_drive {
             fix_paths(wine_c_drive, install_locations)
         } else {
@@ -113,12 +113,12 @@ impl Platform<GogShortcut, GogErrors> for GogPlatform {
                                     None => folder_path.to_string(),
                                 };
 
-                                #[cfg(target_os = "linux")]
+                                #[cfg(target_family = "unix")]
                                 let working_dir = working_dir.replace("\\", "/");
 
                                 let full_path_string = full_path.to_string();
 
-                                #[cfg(target_os = "linux")]
+                                #[cfg(target_family = "unix")]
                                 let full_path_string = full_path_string.replace("\\", "/");
 
                                 let shortcut = GogShortcut {
@@ -151,7 +151,7 @@ impl Platform<GogShortcut, GogErrors> for GogPlatform {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 fn fix_paths(wine_c_drive: &str, paths: Vec<String>) -> Vec<String> {
     paths
         .iter()
@@ -191,7 +191,7 @@ pub fn default_location() -> PathBuf {
         let program_data = std::env::var(key).expect("Expected a APPDATA variable to be defined");
         Path::new(&program_data).join("GOG.com").join("Galaxy")
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     {
         let home = std::env::var("HOME").expect("Expected a home variable to be defined");
         Path::new(&home).join("Games/gog-galaxy/drive_c/ProgramData/GOG.com/Galaxy")

--- a/src/gog/gog_settings.rs
+++ b/src/gog/gog_settings.rs
@@ -5,6 +5,6 @@ pub struct GogSettings {
     pub enabled: bool,
     pub location: Option<String>,
     pub wine_c_drive: Option<String>,
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     pub create_symlinks: bool,
 }

--- a/src/itch/itch_platform.rs
+++ b/src/itch/itch_platform.rs
@@ -55,7 +55,7 @@ impl Platform<ItchGame, ItchErrors> for ItchPlatform {
         Ok(res)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         self.settings.create_symlinks
     }
@@ -92,7 +92,7 @@ fn dbpath_to_game(paths: &DbPaths<'_>) -> Option<ItchGame> {
     })
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 pub fn get_default_location() -> String {
     //If we don't have a home drive we have to just die
     let home = std::env::var("HOME").expect("Expected a home variable to be defined");

--- a/src/itch/settings.rs
+++ b/src/itch/settings.rs
@@ -4,6 +4,6 @@ use serde::{Deserialize, Serialize};
 pub struct ItchSettings {
     pub enabled: bool,
     pub location: Option<String>,
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     pub create_symlinks: bool,
 }

--- a/src/legendary/legendary_platform.rs
+++ b/src/legendary/legendary_platform.rs
@@ -33,7 +33,7 @@ impl Platform<LegendaryGame, Box<dyn Error>> for LegendaryPlatform {
         Ok(legendary_ouput)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         false
     }

--- a/src/origin/origin_platform.rs
+++ b/src/origin/origin_platform.rs
@@ -21,7 +21,7 @@ impl Platform<OriginGame, OriginErrors> for OriginPlatform {
         "Origin"
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         false
     }
@@ -106,7 +106,7 @@ fn parse_id_from_file(i: &str) -> nom::IResult<&str, &str> {
     take_until("&")(i)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 pub fn get_default_location() -> String {
     //TODO implement this for linux:
     // https://www.toptensoftware.com/blog/running-ea-origin-games-under-linux-via-steam-and-proton/

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -12,7 +12,7 @@ where
 
     fn settings_valid(&self) -> SettingsValidity;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool;
 }
 

--- a/src/steam/utils.rs
+++ b/src/steam/utils.rs
@@ -107,13 +107,25 @@ pub fn get_default_location() -> Result<String, Box<dyn Error>> {
                 .unwrap_or(""),
         )
     };
-    #[cfg(target_family = "unix")]
+    #[cfg(target_os = "linux")]
     let path_string = {
         let home = std::env::var("HOME")?;
         String::from(
             Path::new(&home)
                 .join(".steam")
                 .join("steam")
+                .to_str()
+                .unwrap_or(""),
+        )
+    };
+    #[cfg(target_os = "macos")]
+    let path_string = {
+        let home = std::env::var("HOME")?;
+        String::from(
+            Path::new(&home)
+                .join("Library")
+                .join("Application Support")
+                .join("Steam")
                 .to_str()
                 .unwrap_or(""),
         )

--- a/src/steam/utils.rs
+++ b/src/steam/utils.rs
@@ -107,7 +107,7 @@ pub fn get_default_location() -> Result<String, Box<dyn Error>> {
                 .unwrap_or(""),
         )
     };
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     let path_string = {
         let home = std::env::var("HOME")?;
         String::from(

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 mod symlinks;
 mod synchronization;
 

--- a/src/sync/synchronization.rs
+++ b/src/sync/synchronization.rs
@@ -62,9 +62,9 @@ fn fix_shortcut_icons(user: &SteamUsersInfo, shortcuts: &mut Vec<ShortcutOwned>)
         .join("config")
         .join("grid");
     for shortcut in shortcuts {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(target_family = "unix"))]
         let replace_icon = shortcut.icon.trim().eq("");
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         let replace_icon = shortcut.icon.trim().eq("") || shortcut.icon.eq(&shortcut.exe);
         if replace_icon {
             let app_id = steam_shortcuts_util::app_id_generator::calculate_app_id(
@@ -156,7 +156,7 @@ where
             return;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         if platform.create_symlinks() {
             let name = platform.name();
             super::symlinks::ensure_links_folder_created(name);
@@ -179,7 +179,7 @@ where
                     if !shortcut_owned.tags.contains(&boilr_tag) {
                         shortcut_owned.tags.push(boilr_tag.clone());
                     }
-                    #[cfg(target_os = "linux")]
+                    #[cfg(target_family = "unix")]
                     let shortcut_owned = if platform.create_symlinks() {
                         crate::sync::symlinks::create_sym_links(&shortcut_owned)
                     } else {

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -172,12 +172,12 @@ fn update_ui_with_settings(ui: &mut UserInterface, settings: &Settings) {
             .unwrap_or(default_gog_location),
     );
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     {
         ui.gog_winedrive_input
             .set_value(&settings.gog.wine_c_drive.clone().unwrap_or("".to_string()));
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_family = "unix"))]
     {
         ui.gog_winedrive_input.deactivate();
     }

--- a/src/uplay/platform.rs
+++ b/src/uplay/platform.rs
@@ -9,7 +9,7 @@ pub struct Uplay {
 
 impl Platform<Game, Box<dyn Error>> for Uplay {
     fn enabled(&self) -> bool {
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         {
             false
         }
@@ -28,7 +28,7 @@ impl Platform<Game, Box<dyn Error>> for Uplay {
     }
 
     fn get_shortcuts(&self) -> Result<Vec<Game>, Box<dyn Error>> {
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         {
             Ok(vec![])
         }
@@ -38,7 +38,7 @@ impl Platform<Game, Box<dyn Error>> for Uplay {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     fn create_symlinks(&self) -> bool {
         false
     }


### PR DESCRIPTION
Working on https://github.com/PhilipK/BoilR/issues/17

I started by replacing all of the `#[cfg(target_os = "linux")]` with `#[cfg(target_family = "unix")]` since macOS should be similar to Linux

That fixes the compile errors for the base CLI app. 

However, when I tried _running_ the compiled CLI version, it was checking in the wrong directory for the steam files for macos, so I updated `src/steam/utils.rs` to look in the right place.

Despite the Readme saying that Legendary should be enabled by default on Linux, it didn't work until I manually updated `config.toml` to be enabled.


# TODO:
- [ ]  I had a `.DS_STORE` file in my `/Steam/userdata/<numbers>` folder, and BoilR was crashing until I deleted it manually. BoilR should ignore `.DS_STORE` files, because it's normal for macOS to generate those.
- [ ] **UI doesn't seem to work**: When compiling with the UI feature it complains about a `libfltk` file not being compatible with the arm64 architecture (Apple Silicon). Running `cargo update` doesn't fix this. It might be that I need to install some dependencies before trying to build locally.
- [ ] CI scripts need to be updated. They should compile for both `aarch64-apple-darwin` and `x86_64-apple-darwin` on a `macos-latest` machine.
