### PR TITLE
Only add executables from itch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "fltk",
  "fltk-theme",
  "futures",
+ "is_executable",
  "nom 7.0.0",
  "nom_locate",
  "reqwest",
@@ -598,6 +599,15 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "itoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ toml = { version = "^0.5.8", optional = true }
 futures = { version = "^0.3.17" }
 dashmap = { version = "^4.0.2", features = ["serde"] }
 fltk-theme = {version ="0.4" , optional = true }
+is_executable = "1.0.1"
 
 [build-dependencies]
 fl2rust = { version = "0.4", optional = true }


### PR DESCRIPTION
The Itch db can refer to multiple files,
before the first one added was selected,
now the first one that is  executable is selected.