### PR TITLE
Origin proton

### DIFF
--- a/gui/mainview.fl
+++ b/gui/mainview.fl
@@ -75,10 +75,6 @@ class UserInterface {open
           label Origin
           xywh {25 275 155 25} down_box DOWN_BOX
         }
-        Fl_Input origin_folder_input {
-          label {Origin Data Folder}
-          xywh {175 275 300 25} align 5
-        }
       }    
             
       # ----- GOG -----

--- a/src/origin/origin_game.rs
+++ b/src/origin/origin_game.rs
@@ -11,10 +11,10 @@ pub struct OriginGame {
 
 impl From<OriginGame> for ShortcutOwned {
     fn from(game: OriginGame) -> Self {
-        let launch = format!("origin2://game/launch?offerIds={}&autoDownload=1", game.id);
+        let launch = format!("\"origin2://game/launch?offerIds={}&autoDownload=1&authCode=&cmdParams=\"", game.id);
         
         let mut owned_shortcut = if let Some(origin_location)  = game.origin_location{
-            let origin_location = origin_location.to_string_lossy();
+            let origin_location = format!("\"{}\"",origin_location.to_string_lossy());
             Shortcut::new(
                 "0", 
                 game.title.as_str(), 

--- a/src/origin/origin_game.rs
+++ b/src/origin/origin_game.rs
@@ -1,16 +1,40 @@
+use std::path::PathBuf;
+
 use steam_shortcuts_util::{shortcut::ShortcutOwned, Shortcut};
 
 #[derive(Clone)]
 pub struct OriginGame {
     pub id: String,
     pub title: String,
+    pub origin_location : Option<PathBuf>,
 }
 
 impl From<OriginGame> for ShortcutOwned {
     fn from(game: OriginGame) -> Self {
         let launch = format!("origin2://game/launch?offerIds={}&autoDownload=1", game.id);
-        let shortcut = Shortcut::new("0", game.title.as_str(), launch.as_str(), "", "", "", "");
-        let mut owned_shortcut = shortcut.to_owned();
+        
+        let mut owned_shortcut = if let Some(origin_location)  = game.origin_location{
+            let origin_location = origin_location.to_string_lossy();
+            Shortcut::new(
+                "0", 
+                game.title.as_str(), 
+                &origin_location, 
+                "", 
+                "", 
+                "", 
+                launch.as_str()
+            ).to_owned()
+        }else{
+            Shortcut::new(
+                "0", 
+                game.title.as_str(), 
+                launch.as_str(), 
+                "", 
+                "", 
+                "", 
+                ""
+            ).to_owned()
+        };
         owned_shortcut.tags.push("Origin".to_owned());
         owned_shortcut.tags.push("Ready TO Play".to_owned());
         owned_shortcut.tags.push("Installed".to_owned());

--- a/src/origin/origin_platform.rs
+++ b/src/origin/origin_platform.rs
@@ -166,7 +166,7 @@ struct OriginPathData{
 
 
 #[cfg(target_os = "windows")]
-pub fn get_default_locations() -> OriginPathData {
+fn get_default_locations() -> OriginPathData {
     let mut res = OriginPathData::default();
 
     let key = "PROGRAMDATA";

--- a/src/origin/origin_platform.rs
+++ b/src/origin/origin_platform.rs
@@ -174,7 +174,7 @@ pub fn get_default_locations() -> OriginPathData {
     if let Ok(program_data) =program_data {
         let origin_folder = Path::new(&program_data)
         .join("Origin");
-        if origin_folder.exsits(){
+        if origin_folder.exists(){
             res.exe_path = Some(origin_folder.to_owned());
         }
     }

--- a/src/origin/settings.rs
+++ b/src/origin/settings.rs
@@ -4,5 +4,4 @@ use serde::{Deserialize, Serialize};
 
 pub struct OriginSettings {
     pub enabled: bool,
-    pub path: Option<String>,
 }

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -73,7 +73,6 @@ fn update_settings_with_ui_values(settings: &mut Settings, ui: &UserInterface) {
 
     // Origin
     settings.origin.enabled = ui.enable_origin_checkbox.value();
-    settings.origin.path = empty_or_whitespace(ui.origin_folder_input.value());
 
     // Epic
     settings.epic_games.enabled = ui.enable_egs_checkbox.value();
@@ -107,7 +106,7 @@ fn save_settings_to_file(settings: &Settings) {
 fn update_ui_with_settings(ui: &mut UserInterface, settings: &Settings) {
     use std::path::Path;
 
-    use crate::{gog, itch, origin, steam};
+    use crate::{gog, itch, steam};
 
     ui.steam_location_input.set_value(
         &settings
@@ -167,18 +166,6 @@ fn update_ui_with_settings(ui: &mut UserInterface, settings: &Settings) {
             .unwrap_or(default_itch_location),
     );
     ui.enable_origin_checkbox.set_value(settings.origin.enabled);
-    let mut default_origin_location = origin::get_default_location();
-    if !Path::new(&default_origin_location).exists() {
-        default_origin_location = String::from("");
-    }
-    ui.origin_folder_input.set_value(
-        &settings
-            .origin
-            .path
-            .clone()
-            .unwrap_or(default_origin_location),
-    );
-
     ui.enable_gog_checkbox.set_value(settings.gog.enabled);
     let default_gog_location = gog::default_location();
     let default_gog_location = if !default_gog_location.exists() {


### PR DESCRIPTION
This changes the way that origin games are found on Linux.
It now tries to find origin itself instead of expecting the user to input where it is.
If origin is installed using proton, then the games should be found and launched correctly.