### PR TITLE
Multiple improvements for steamdeck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ version = "1.2.0"
 dependencies = [
  "base64",
  "config",
+ "copypasta",
  "dashmap",
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ image = { version = "0.24.1", features = ["png"] }
 toml = { version = "^0.5.8" }
 sysinfo = "0.23.10"
 sqlite = "0.26.0"
+copypasta = "0.7.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"


### PR DESCRIPTION
Multiple improvements for the Steam Deck (and others too).

Including: 
* Paste the SteamgridDB API key in from clipboard automatically if it looks like a API key. This is nice for steam deck so you don't have to do a right-click paste or worse manually write in the key.
* BoilR guesses what game it should find images for based on the game name, but it might be wrong, it is now possible to correct this
* No longer show a back button on the user select screen (it did nothing)
* Now you can change the images for ALL your shortcuts, not just the BoilR ones.