### PR TITLE
Add option to ban download of images

### DIFF
--- a/src/defaultconfig.toml
+++ b/src/defaultconfig.toml
@@ -5,6 +5,7 @@ blacklisted_games = []
 auth_key = "Write your authentication key between these quotes"
 enabled = true
 prefer_animated = false
+banned_images = []
 
 [origin]
 enabled = true

--- a/src/steamgriddb/downloader.rs
+++ b/src/steamgriddb/downloader.rs
@@ -51,6 +51,7 @@ pub async fn download_images_for_users<'b>(
                         client,
                         download_animated,
                         settings.steam.optimize_for_big_picture,
+                        settings,
                     )
                     .await;
                     res.unwrap_or_default()
@@ -133,6 +134,7 @@ async fn search_for_images_to_download(
     client: &Client,
     download_animated: bool,
     download_big_picture: bool,
+    settings: &Settings,
 ) -> Result<Vec<ToDownload>, Box<dyn Error>> {
     let types = {
         let mut types = vec![
@@ -185,6 +187,7 @@ async fn search_for_images_to_download(
         let images_needed = shortcuts
             .iter()
             .filter(|s| search_results.contains_key(&s.app_id))
+            .filter(|s| !settings.steamgrid_db.is_image_banned(&image_type, s.app_id))
             .filter(|s| !known_images.contains(&image_type.file_name(s.app_id)));
         let image_ids: Vec<usize> = images_needed
             .clone()

--- a/src/steamgriddb/settings.rs
+++ b/src/steamgriddb/settings.rs
@@ -1,8 +1,29 @@
 use serde::{Deserialize, Serialize};
 
+use super::ImageType;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SteamGridDbSettings {
     pub enabled: bool,
     pub auth_key: Option<String>,
     pub prefer_animated: bool,
+    pub banned_images: Vec<String>,
+}
+
+impl SteamGridDbSettings {
+    pub fn is_image_banned(&self, image_type: &ImageType, app_id: u32) -> bool {
+        let ban_id = format!("{}-{}", app_id, image_type.name());
+        self.banned_images.contains(&ban_id)
+    }
+
+    pub fn set_image_banned(&mut self, image_type: &ImageType, app_id: u32, should_ban: bool) {
+        let ban_id = format!("{}-{}", app_id, image_type.name());
+        let images_banned = &mut self.banned_images;
+        let is_banned = images_banned.contains(&ban_id);
+        match (is_banned, should_ban) {
+            (true, false) => images_banned.retain(|i| !i.eq(&ban_id)),
+            (false, true) => images_banned.push(ban_id),
+            _ => {}
+        }
+    }
 }


### PR DESCRIPTION
This lets users ban download of specific images.
A ban will prevent BoilR from changing that image type for that shortcut.

This should fix:
https://github.com/PhilipK/BoilR/issues/104

