### PR TITLE
Fix not finding certain GOG games that use launchers

### DIFF
--- a/src/gog/gog_platform.rs
+++ b/src/gog/gog_platform.rs
@@ -57,7 +57,10 @@ fn get_shortcuts_from_games(games: Vec<(GogGame, PathBuf)>) -> Vec<GogShortcut> 
                 if let Some(primary_task) = tasks.iter().find(|t| {
                     t.is_primary.unwrap_or_default()
                         && t.task_type == "FileTask"
-                        && t.category.as_ref().unwrap_or(&String::from("")) == "game"
+                        && (
+                            t.category.as_ref().unwrap_or(&String::from("")) == "launcher" || 
+                            t.category.as_ref().unwrap_or(&String::from("")) == "game"
+                        )
                 }) {
                     if let Some(task_path) = &primary_task.path {
                         let full_path = game_folder.join(&task_path);


### PR DESCRIPTION
Encountered an issue where BoilR would miss some of my GOG client games; turns out their `goggame-*.info` file has their first playTask category field set to "launcher", and BoilR was skipping over them because of this. This fixes it by matching on either "launcher" or "game". 