### PR TITLE
Fix the potential redundant_clone issue of path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,3 +51,40 @@ pub fn get_backups_flder() -> PathBuf {
 pub fn get_boilr_links_path() -> PathBuf {
     get_config_folder().join("links")
 }
+
+
+#[cfg(test)]
+mod tests{
+    use std::path::PathBuf;
+
+    use super::get_config_folder;
+
+    #[test]
+
+    #[cfg(target_family = "unix")]
+    fn check_return_xdg_config_path(){
+
+        // Parameters for set environment 'XDG_CONFIG_HOME'
+        std::env::set_var("XDG_CONFIG_HOME", std::env::var("HOME").unwrap()+"/.config/boilr");
+
+        let xdg_config_home=std::env::var("XDG_CONFIG_HOME").unwrap();
+        let config_path=get_config_folder();
+        let test_path=PathBuf::from(xdg_config_home);
+
+        assert_eq!(config_path,test_path);
+    }
+
+
+    #[test]
+
+    #[cfg(target_family = "unix")]
+    fn check_return_config_path(){
+
+        std::env::set_var("XDG_CONFIG_HOME", std::env::var("HOME").unwrap()+"/.config/boilr");
+        
+        let config_path=get_config_folder();
+        let current_path=std::env::var("HOME").unwrap()+"/.config/boilr";
+
+        assert_eq!(config_path,PathBuf::from(current_path));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

Hi @PhilipK , thanks for your work. 

It is awesome. I fix a little bit potential issue for BoileR. I'm a big fan of Steam Deck, although my order was suspended in Canada.

Even though I cannot test it on my Steam Deck, I add a simple test case to support it does not change any useful feature. Here below,

```
 *  Executing task: cargo test --package boilr --bin boilr -- config::tests::check_return_config_format --exact --nocapture 

   Compiling boilr v1.5.1 (/workspaces/BoilR)
    Finished test [unoptimized + debuginfo] target(s) in 28.74s
     Running unittests src/main.rs (target/debug/deps/boilr-23166f7cd679110a)

running 1 test
test config::tests::check_return_config_format ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.00s

 *  Terminal will be reused by tasks, press any key to close it. 
```