### PR TITLE
Fix Proton installed EGS games not found

### DIFF
--- a/src/platforms/egs/get_manifests.rs
+++ b/src/platforms/egs/get_manifests.rs
@@ -3,7 +3,7 @@ use super::ManifestItem;
 
 use std::fs::{DirEntry, File};
 use std::io::BufReader;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(crate) fn get_egs_manifests(
     settings: &EpicGamesLauncherSettings,
@@ -16,33 +16,11 @@ pub(crate) fn get_egs_manifests(
 
             match manifest_dir_result {
                 Ok(manifest_dir) => {
-                    let mut all_manifests = manifest_dir
+                    let mut manifests: Vec<ManifestItem> = manifest_dir
                         .filter_map(|dir| dir.ok())
-                        .filter_map(get_manifest_item);
-                    #[cfg(target_family = "unix")]
-                    {
-                        for mut manifest in &mut all_manifests {
-                            if let Some(compat_folder) = locations.compat_folder_path.as_ref() {
-                                //Strip off the c:\\
-                                manifest.manifest_location = compat_folder
-                                    .join("pfx")
-                                    .join("drive_c")
-                                    .join(&manifest.manifest_location[3..].replace('\\', "/"))
-                                    .to_path_buf()
-                                    .to_string_lossy()
-                                    .to_string();
-
-                                manifest.install_location = compat_folder
-                                    .join("pfx")
-                                    .join("drive_c")
-                                    .join(&manifest.install_location[3..].replace('\\', "/"))
-                                    .to_path_buf()
-                                    .to_string_lossy()
-                                    .to_string();
-                            }
-                        }
-                    }
-                    let mut manifests: Vec<ManifestItem> = all_manifests
+                        .filter_map(|dir| {
+                            get_manifest_item(dir, locations.compat_folder_path.clone())
+                        })
                         .filter(is_game_installed)
                         .filter(is_game_launchable)
                         .collect();
@@ -79,12 +57,40 @@ fn is_game_launchable(manifest: &ManifestItem) -> bool {
     (!manifest.launch_executable.is_empty()) || (manifest.is_managed)
 }
 
-fn get_manifest_item(dir_entry: DirEntry) -> Option<ManifestItem> {
+fn get_manifest_item(dir_entry: DirEntry, _path: Option<PathBuf>) -> Option<ManifestItem> {
     if let Some(extension) = dir_entry.path().extension() {
         if extension.eq("item") {
             if let Ok(file) = File::open(dir_entry.path()) {
                 let reader = BufReader::new(file);
-                return serde_json::from_reader(reader).ok();
+
+                #[cfg(target_family = "unix")]
+                {
+                    if let Ok(mut item) = serde_json::from_reader::<_, ManifestItem>(reader) {
+                        if let Some(compat_folder) = _path {
+                            //Strip off the c:\\
+                            item.manifest_location = compat_folder
+                                .join("pfx")
+                                .join("drive_c")
+                                .join(&item.manifest_location[3..].replace('\\', "/"))
+                                .to_path_buf()
+                                .to_string_lossy()
+                                .to_string();
+
+                            item.install_location = compat_folder
+                                .join("pfx")
+                                .join("drive_c")
+                                .join(&item.install_location[3..].replace('\\', "/"))
+                                .to_path_buf()
+                                .to_string_lossy()
+                                .to_string();
+
+                            return Some(item);
+                        }
+                    }
+                }
+
+                #[cfg(not(target_family = "unix"))]
+                return serde_json::from_reader::<_, ManifestItem>(reader).ok();
             }
         }
     }


### PR DESCRIPTION
Fixes #165 

I came across this issue earlier today after setting up EGS on my Steam Deck, so I thought I'd give it a go.

Previously, `all_manifests` would be consumed by the for loop, so would then be collected into an empty Vec.

This PR changes how the manifests are filtered to be all in one go and moves the handling of Windows paths to where the manifest is parsed.

Tested on the Steam Deck with EGS installed using Proton, games are now found as expected. Also tested on Windows 11.

Appreciate any feedback!