### PR TITLE
Add ro access to legendary folder

### DIFF
--- a/flatpak/io.github.philipk.boilr.yml
+++ b/flatpak/io.github.philipk.boilr.yml
@@ -14,7 +14,7 @@ build-options:
 
 command: boilr
 finish-args:
-  - --filesystem=~/.config/legendary:rw # Legendary
+  - --filesystem=~/.config/legendary:ro # Legendary
   - --filesystem=xdg-data/Steam:rw
   - --filesystem=~/.steam:rw # Steam (Non-flatpak)
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw # Steam (Flatpak)


### PR DESCRIPTION
Add missing rw access in order to detect heroic / legendary games using user binary heroic launcher.