### PR TITLE
Games installed through EGS not getting detected.

### DIFF
--- a/src/platforms/egs/get_manifests.rs
+++ b/src/platforms/egs/get_manifests.rs
@@ -70,7 +70,8 @@ fn get_manifest_item(dir_entry: DirEntry, _path: Option<PathBuf>) -> Option<Mani
                             //Strip off the c:\\
                             item.manifest_location = compat_folder
                                 .join("pfx")
-                                .join("drive_c")
+                                .join("dosdevices")
+                                .join(&item.manifest_location[0..2].to_lowercase())
                                 .join(&item.manifest_location[3..].replace('\\', "/"))
                                 .to_path_buf()
                                 .to_string_lossy()
@@ -78,7 +79,8 @@ fn get_manifest_item(dir_entry: DirEntry, _path: Option<PathBuf>) -> Option<Mani
 
                             item.install_location = compat_folder
                                 .join("pfx")
-                                .join("drive_c")
+                                .join("dosdevices")
+                                .join(&item.install_location[0..2].to_lowercase())
                                 .join(&item.install_location[3..].replace('\\', "/"))
                                 .to_path_buf()
                                 .to_string_lossy()


### PR DESCRIPTION
The manifest files and install locations is always "pfx/drive_c" this may not be true if the games were installed on SD Card. 
Using the installed and manifest locations from the .item file through dosdevices directory solves this problem. 

https://github.com/PhilipK/BoilR/issues/279