### PR TITLE
EGS Shortcut fix

### DIFF
--- a/src/platforms/egs/paths.rs
+++ b/src/platforms/egs/paths.rs
@@ -40,7 +40,7 @@ mod unix {
                         .join("Program Files (x86)")
                         .join("Epic Games")
                         .join("Launcher")
-                        .join("Engine")
+                        .join("Portal")
                         .join("Binaries");
                     if binary_path.exists() {
                         let launcher_path = if binary_path


### PR DESCRIPTION
Currently the EGS shortcut picks EpicGamesLauncher.exe from the Engine Directory. 
When the shortcut is launched, the EGS shows up but doesn't launch the game. This works when we use the exe from Portal Directory. Hence the PR. 