### PR TITLE
New cli options to use lutris service_games

### DIFF
--- a/src/platforms/lutris/game_list_parser.rs
+++ b/src/platforms/lutris/game_list_parser.rs
@@ -29,7 +29,7 @@ mod tests {
 
         let games = parse_lutris_games(content);
 
-        assert_eq!(games[0].id, 1);
+        assert_eq!(games[0].id, 48);
     }
 
     #[test]
@@ -40,7 +40,7 @@ mod tests {
 
         assert_eq!(
             games[5].name,
-            "The Witcher 3: Wild Hunt - Game of the Year Edition"
+            "Wolfenstein: The New Order"
         );
     }
 
@@ -52,7 +52,7 @@ mod tests {
 
         assert_eq!(
             games[5].slug,
-            "the-witcher-3-wild-hunt-game-of-the-year-edition"
+            "wolfenstein_the_new_order"
         );
     }
 
@@ -62,6 +62,6 @@ mod tests {
 
         let games = parse_lutris_games(content);
 
-        assert_eq!(games[1].runner, "steam");
+        assert_eq!(games[1].service, "steam");
     }
 }

--- a/src/platforms/lutris/lutris_game.rs
+++ b/src/platforms/lutris/lutris_game.rs
@@ -9,8 +9,9 @@ pub struct LutrisGame {
     pub id: i64,
     pub slug: String,
     pub name: String,
-    pub runner: String,
-    pub platform: String,
+    pub service: String,
+    pub installed: bool,
+    pub details: String,
     pub settings: Option<LutrisSettings>,
 }
 
@@ -40,7 +41,7 @@ impl LutrisGame {
             .unwrap_or_default();
         if is_flatpak {
             format!(
-                "run {} lutris:rungame/{}",
+                "run {} lutris:{}",
                 self.settings
                     .as_ref()
                     .map(|s| s.flatpak_image.clone())
@@ -48,7 +49,7 @@ impl LutrisGame {
                 self.slug
             )
         } else {
-            format!("lutris:rungame/{}", self.slug)
+            format!("lutris:{}", self.slug)
         }
     }
 

--- a/src/platforms/lutris/settings.rs
+++ b/src/platforms/lutris/settings.rs
@@ -6,6 +6,7 @@ pub struct LutrisSettings {
     pub executable: String,
     pub flatpak: bool,
     pub flatpak_image: String,
+    pub installed: bool,
 }
 
 impl Default for LutrisSettings {
@@ -21,6 +22,7 @@ impl Default for LutrisSettings {
             executable: "lutris".to_string(),
             flatpak: true,
             flatpak_image: "net.lutris.Lutris".to_string(),
+            installed: true,
         }
     }
 }

--- a/src/platforms/lutris/test_output.txt
+++ b/src/platforms/lutris/test_output.txt
@@ -1,74 +1,50 @@
 [
   {
-    "id": 1,
-    "slug": "aperture-desk-job",
-    "name": "Aperture Desk Job",
-    "runner": "steam",
-    "platform": "Linux",
-    "year": null,
-    "directory": null,
-    "hidden": false,
-    "playtime": null,
-    "lastplayed": null
+    "id": 48,
+    "slug": "dishonored_2",
+    "name": "Dishonored 2",
+    "service": "gog",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1431426311, \"availability\": {\"isAvailable\": true, \"isAvailableInAccount\": true}, \"title\": \"Dishonored 2\", \"image\": \"//images-2.gog-statics.com/65811050eda91f39725b29a46ca7c7e68bdd7ec515ab4ef127dc96d77fab0c44\", \"url\": \"/en/game/dishonored_2\", \"worksOn\": {\"Windows\": true, \"Mac\": false, \"Linux\": false}, \"category\": \"Action\", \"rating\": 44, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"dishonored_2\", \"updates\": 0, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2016-11-11 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   },
   {
-    "id": 2,
-    "slug": "dark-souls-iii",
-    "name": "DARK SOULS\u2122 III",
-    "runner": "steam",
-    "platform": "Linux",
-    "year": null,
-    "directory": null,
-    "hidden": false,
-    "playtime": null,
-    "lastplayed": null
+    "id": 41,
+    "slug": "middleearth_shadow_of_mordor",
+    "name": "Middle-earth\u2122: Shadow of Mordor\u2122 Game of the Year Edition",
+    "service": "steam",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1213504814, \"availability\": {\"isAvailable\": true, \"isAvailableInAccount\": true}, \"title\": \"Middle-earth\\u2122: Shadow of Mordor\\u2122 Game of the Year Edition\", \"image\": \"//images-2.gog-statics.com/455ff8097ca01fe893703d38b20f46bc9a539765256f9755ea9e592f48938763\", \"url\": \"/en/game/middleearth_shadow_of_mordor\", \"worksOn\": {\"Windows\": true, \"Mac\": false, \"Linux\": false}, \"category\": \"Action\", \"rating\": 0, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"middleearth_shadow_of_mordor\", \"updates\": 0, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2014-09-30 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   },
   {
-    "id": 4,
-    "slug": "disco-elysium",
-    "name": "Disco Elysium",
-    "runner": "wine",
-    "platform": "Windows",
-    "year": 2019,
-    "directory": "/home/deck/Games/gog/disco-elysium",
-    "hidden": false,
-    "playtime": "0:01:16",
-    "lastplayed": "2022-07-25 23:21:56"
+    "id": 10,
+    "slug": "prey",
+    "name": "Prey",
+    "service": "gog",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1158493447, \"availability\": {\"isAvailable\": true, \"isAvailableInAccount\": true}, \"title\": \"Prey\", \"image\": \"//images-1.gog-statics.com/ed7a5f0cba0e3ee80bc5dd10683f6ce6fe692bb2b1764c4987aa97fbaaf142d1\", \"url\": \"/en/game/prey\", \"worksOn\": {\"Windows\": true, \"Mac\": false, \"Linux\": false}, \"category\": \"Action\", \"rating\": 44, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"prey\", \"updates\": 1, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2017-05-04 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   },
   {
-    "id": 3,
-    "slug": "hollow-knight",
-    "name": "Hollow Knight",
-    "runner": "steam",
-    "platform": "Linux",
-    "year": null,
-    "directory": null,
-    "hidden": false,
-    "playtime": null,
-    "lastplayed": null
+    "id": 53,
+    "slug": "the_elder_scrolls_iii_morrowind_goty_edition_game",
+    "name": "The Elder Scrolls III: Morrowind GOTY Edition",
+    "service": "gog",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1435828767, \"availability\": {\"isAvailable\": false, \"isAvailableInAccount\": true}, \"title\": \"The Elder Scrolls III: Morrowind GOTY Edition\", \"image\": \"//images-2.gog-statics.com/e19e2055ee1d083793a4ea093872f15b749e3d75384bf8c0f3d81002a4a4fd47\", \"url\": \"/en/game/the_elder_scrolls_iii_morrowind_goty_edition\", \"worksOn\": {\"Windows\": true, \"Mac\": false, \"Linux\": false}, \"category\": \"Role-playing\", \"rating\": 0, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"the_elder_scrolls_iii_morrowind_goty_edition_game\", \"updates\": 0, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2003-11-07 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   },
   {
-    "id": 7,
-    "slug": "lumino-city",
-    "name": "Lumino City",
-    "runner": "wine",
-    "platform": "Windows",
-    "year": null,
-    "directory": "/home/deck/Games/gog/lumino-city",
-    "hidden": false,
-    "playtime": null,
-    "lastplayed": null
+    "id": 24,
+    "slug": "the_witcher_2",
+    "name": "The Witcher 2: Assassins of Kings Enhanced Edition",
+    "service": "gog",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1207658930, \"availability\": {\"isAvailable\": true, \"isAvailableInAccount\": true}, \"title\": \"The Witcher 2: Assassins of Kings Enhanced Edition\", \"image\": \"//images-4.gog-statics.com/8355e657a19311b158a3553a154e109199d6991c7791a20c3305af1f84d15ed7\", \"url\": \"/en/game/the_witcher_2\", \"worksOn\": {\"Windows\": true, \"Mac\": true, \"Linux\": true}, \"category\": \"Role-playing\", \"rating\": 47, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"the_witcher_2\", \"updates\": 1, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2012-04-17 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   },
   {
-    "id": 5,
-    "slug": "the-witcher-3-wild-hunt-game-of-the-year-edition",
-    "name": "The Witcher 3: Wild Hunt - Game of the Year Edition",
-    "runner": "wine",
-    "platform": "Windows",
-    "year": 2015,
-    "directory": "/home/deck/Games/gog/the-witcher-3-wild-hunt-game-of-the-year-edition",
-    "hidden": false,
-    "playtime": "0:00:54",
-    "lastplayed": "2022-07-25 23:20:40"
+    "id": 70,
+    "slug": "wolfenstein_the_new_order",
+    "name": "Wolfenstein: The New Order",
+    "service": "gog",
+    "installed": false,
+    "details": "{\"isGalaxyCompatible\": true, \"tags\": [], \"id\": 1943729964, \"availability\": {\"isAvailable\": true, \"isAvailableInAccount\": true}, \"title\": \"Wolfenstein: The New Order\", \"image\": \"//images-2.gog-statics.com/b2c4a0bae46c1432da6eddfd2783bfdb5ec91c04c72f712eb1b236aaf0d98519\", \"url\": \"/en/game/wolfenstein_the_new_order\", \"worksOn\": {\"Windows\": true, \"Mac\": false, \"Linux\": false}, \"category\": \"Shooter\", \"rating\": 38, \"isComingSoon\": false, \"isMovie\": false, \"isGame\": true, \"slug\": \"wolfenstein_the_new_order\", \"updates\": 0, \"isNew\": true, \"dlcCount\": 0, \"releaseDate\": {\"date\": \"2014-05-20 00:00:00.000000\", \"timezone_type\": 3, \"timezone\": \"Europe/Nicosia\"}, \"isBaseProductMissing\": false, \"isHidingDisabled\": false, \"isInDevelopment\": false, \"extraInfo\": [], \"isHidden\": false}"
   }
 ]


### PR DESCRIPTION
Related to https://github.com/PhilipK/BoilR/issues/290

I had the same desire to see all my games in Steam, mostly so I could use deckroulette on them. Lutris seemed like an easy linux based option, so I submitted a pull request to add a new CLI option to Lutris that would extract all of a users games, whether they're installed or not.

https://github.com/lutris/lutris/pull/4990

It uses a different table in Lutris so the fields returned are slightly different, but the same `-o` and `-j` arguments still work. I've prepared this pull request in case you're interested in adopting the new CLI option, though given the changes if you are interested it might be best to wait until they next put out a release. 

List of changes:

- Adds new option to toggle searching just installed Lutris games (defaults to existing behaviour)
- Uses the new `-a` option on the Lutris CLI which returns items from the `service_games` table instead of games
- Updated checks and tests to use fields from `service_games` table
- Changed launch command to `lutris:{game_name}` as this installs the game via Lutris, or plays it if already installed.

Please let me know what you think, or if you'd like any changes made.

I was also considering a change to the `Shortcut` object in https://github.com/PhilipK/steam_shortcuts_util/blob/main/src/shortcut.rs to add a field for service like GOG or EGS to help distinguish if you have the same game across multiple services in Lutris/Playnite etc. It could be set to the name of the platform for single service platforms and be shown next to the game title in BoilR.

