### PR TITLE
Set Heroic legendary config file to new location

### DIFF
--- a/src/platforms/heroic/heroic_platform.rs
+++ b/src/platforms/heroic/heroic_platform.rs
@@ -37,8 +37,8 @@ fn get_installed_json_location(install_mode: &InstallationMode) -> PathBuf {
     let home_dir = std::env::var("HOME").unwrap_or_else(|_| "".to_string());
     match install_mode {
         InstallationMode::FlatPak => Path::new(&home_dir)
-            .join(".var/app/com.heroicgameslauncher.hgl/config/legendary/installed.json"),
-        InstallationMode::UserBin => Path::new(&home_dir).join(".config/legendary/installed.json"),
+            .join(".var/app/com.heroicgameslauncher.hgl/config/heroic/legendaryConfig/legendary/installed.json"),
+        InstallationMode::UserBin => Path::new(&home_dir).join(".config/heroic/legendaryConfig/legendary/installed.json"),
     }
 }
 


### PR DESCRIPTION
This solves the following issue:
https://github.com/PhilipK/BoilR/issues/361

By updating the location of the heroic legendary config file to the new location.
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/e6a30329f896bb1eb16d653d13b72e9538a75dc8/src/backend/constants.ts#L78-L79