### PR TITLE
fix Steam stop function, it can get into an infinite loop

### DIFF
--- a/src/steam/restarter.rs
+++ b/src/steam/restarter.rs
@@ -19,8 +19,12 @@ pub fn ensure_steam_stopped() {
         let pid = process.pid();
         let pid_arr = [pid];
         let process_to_update = ProcessesToUpdate::Some(&pid_arr);
-        while s.refresh_processes_specifics(process_to_update, true,ProcessRefreshKind::everything()) == 0{
-            println!("Waiting for steam to stop");
+
+        while s.refresh_processes_specifics(process_to_update, true,ProcessRefreshKind::everything()) > 0 
+                // The process is still alive
+                && s.process(pid).is_some()
+                 {
+            println!("Waiting for steam to stop. PID: {:?}", pid);
             sleep(Duration::from_millis(500));
             process.kill_with(sysinfo::Signal::Quit);
             process.kill_with(sysinfo::Signal::Kill);

--- a/src/steam/restarter.rs
+++ b/src/steam/restarter.rs
@@ -30,6 +30,7 @@ pub fn ensure_steam_stopped() {
             process.kill_with(sysinfo::Signal::Kill);
         }
     }
+    println!("Steam is stopped");
 }
 #[cfg(target_os = "windows")]
 pub fn ensure_steam_started(settings: &super::SteamSettings) {

--- a/src/steam/restarter.rs
+++ b/src/steam/restarter.rs
@@ -14,9 +14,18 @@ pub fn ensure_steam_stopped() {
     let processes = s.processes_by_name(os_steam_name);
     for process in processes {
         let mut s = System::new();
-        process.kill_with(sysinfo::Signal::Quit);
-        process.kill_with(sysinfo::Signal::Kill);
+
+        let quit_res = process.kill_with(sysinfo::Signal::Quit);
+        let kill_res = process.kill_with(sysinfo::Signal::Kill);
+
+        if quit_res == Some(false) && kill_res == Some(false) {
+            // Couldn't kill the process, this could be because it was already killed or we don't have permissions
+            // For instance, the process "steamos-manager" in the Steam Deck is owned by root
+            continue;
+        }
+        
         let pid = process.pid();
+        let process_name = process.name();
         let pid_arr = [pid];
         let process_to_update = ProcessesToUpdate::Some(&pid_arr);
 
@@ -24,7 +33,7 @@ pub fn ensure_steam_stopped() {
                 // The process is still alive
                 && s.process(pid).is_some()
                  {
-            println!("Waiting for steam to stop. PID: {:?}", pid);
+            println!("Waiting for steam to stop. PID: {pid:?} Name: {process_name:?}");
             sleep(Duration::from_millis(500));
             process.kill_with(sysinfo::Signal::Quit);
             process.kill_with(sysinfo::Signal::Kill);


### PR DESCRIPTION
Since a recent update I encountered that the "wait for Steam to close" function was getting stuck.
The problem seems to be the change in the `while` loop exit condition in 10caa7bee196922cc3f9df1354cc3516b89fa515

We can additionally check if the process is still alive.

What do you think?