### PR TITLE
Fix mistake under "GOG" in Tips for Linux

### DIFF
--- a/tips_for_linux.md
+++ b/tips_for_linux.md
@@ -4,7 +4,7 @@ If you are on Linux, and want to use one of the launchers that is not available 
 If you want to avoid launching into Lutris, here are a few ways that you can do that.
 
 ### GOG
-I recommend you just use Heroic. But if you really really want to use EGS you can:
+I recommend you just use Heroic. But if you really really want to use GOG Galaxy you can:
 
 - Install [Lutris](https://lutris.net/)
 - Install GOG from Lutris [here](https://lutris.net/games/gog-galaxy/)


### PR DESCRIPTION
Just spotted a little error - EGS is mentioned in the section for GOG Galaxy in the tips_for_linux.md documentation file.