### PR TITLE
Add itch.io flatpaked path to flatpak manifest

### DIFF
--- a/flatpak/io.github.philipk.boilr.yml
+++ b/flatpak/io.github.philipk.boilr.yml
@@ -22,7 +22,8 @@ finish-args:
   - --filesystem=~/.var/app/net.lutris.Lutris:rw # Lutris (Flatpak)
   - --filesystem=~/Games/Heroic:rw # Heroic (non-flatpak)
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl:rw # Heroic (Flatpak)
-  - --filesystem=~/.config/itch:rw # Itch
+  - --filesystem=~/.config/itch:rw # Itch (non-flatpak)
+  - --filesystem=~/.var/app/io.itch.itch/config/itch:rw # Itch (Flatpak)
   - --talk-name=org.freedesktop.Flatpak
   - --filesystem=xdg-data/flatpak:ro
 


### PR DESCRIPTION
Lets BoilR access the installation directory of Itch when that is installed as a Flatpak.

Didn't test building the flatpak, however it works for me when adding access to the same path via the KDE settings panel.