### PR TITLE
Add support for native platform bottles instead of only flatpak

### DIFF
--- a/apps/boilr-tauri/package-lock.json
+++ b/apps/boilr-tauri/package-lock.json
@@ -69,6 +69,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1231,6 +1232,7 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1432,6 +1434,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -1965,6 +1968,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2296,6 +2300,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2465,6 +2470,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2827,6 +2833,7 @@
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -2960,6 +2967,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Purpose
The existing implementation for Bottles only supports the Flatpak version of bottles.  As is the case with many Flatpak's, bottles can be limited by Flatpak, and as such, some users prefer to run bottles native(such as through an aur install on arch).

## This PR adds a new setting in the Bottles section:
### "Use Flatpak version"
- When enabled, BoilR will search for bottles games using the Flatpak version of bottles-cli, and will make shortcuts in Steam using the Flatpack version of bottles-cli launcher.  (This is the default behavior.)
- When disabled, BoilR will us the native versions of bottles-cli to search for bottles, as well as in the Steam shortcuts.

## Implementation
All code changes were done in the bottles platform.rs and tested in both the legacy egui and new tauri ui.

## Potential Issues
This changes the default behavior of the bottles implementation to assume "native" mode not "flatpak" mode.
You may want to change the code to default to "flatpak" mode for backward compatibility when users upgrade.

## Related bugs that should be solved
- #448 
- #405 
- #240 